### PR TITLE
fix: Prevent password re-hashing on user update

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -18,7 +18,7 @@ class User extends Model {
         sequelize,
         hooks: {
           beforeSave: async (user) => {
-            if (user.password) {
+            if (user.changed('password')) {
               user.password = await bcrypt.hash(user.password, 8);
             }
           },


### PR DESCRIPTION
The `beforeSave` hook on the `User` model was re-hashing the user's password on every update, even when the password itself was not being changed. This was causing the user's password to be invalidated whenever an OTP was requested or any other user property was updated.

This commit fixes the bug by modifying the `beforeSave` hook to only hash the password if the `password` field has actually been changed, using `user.changed('password')`.